### PR TITLE
Fix server static issue

### DIFF
--- a/exampleQuiz.json
+++ b/exampleQuiz.json
@@ -1,12 +1,12 @@
 {
-    "_id": "1923",
+    "_id": "1",
     "name": "State Capitals",
     "description": "The capitals of all 50 states in the U.S.",
     "creation_date": "1559404138",
     "tags": [
         "Geography", "US", "Trivia"
     ],
-    "card_count": "2",
+    "card_count": "13",
     "cards": [{
         "prompt": "Alabama",
         "answer": "Montgomery"

--- a/server.js
+++ b/server.js
@@ -13,23 +13,14 @@ app.set('view engine', 'handlebars')
 
 var port = process.env.PORT || 3000
 
-app.get('*/style.css', function(req, res) {
-    fs.readFile('public/style.css', function read(err, data) {
-        res.statusCode = 200
-        res.setHeader('Content-Type', 'text/css')
-        res.write(data)
-        res.end()
-    })
+app.all("*/public/:page", function (req, res, next) {
+    var page = req.params.page
+    console.log("Redirecting");
+    console.log(req.originalUrl)
+    res.redirect('/' + page)
 })
 
-app.get('*/global.css', function(req, res) {
-    fs.readFile('public/global.css', function read(err, data) {
-        res.statusCode = 200
-        res.setHeader('Content-Type', 'text/css')
-        res.write(data)
-        res.end()
-    })
-})
+app.use(express.static('public'))
 
 app.get('/', function(req, res) {
     res.status(200).render('home')

--- a/server.js
+++ b/server.js
@@ -13,7 +13,7 @@ app.set('view engine', 'handlebars')
 
 var port = process.env.PORT || 3000
 
-app.all("*/public/:page", function (req, res, next) {
+app.get("*/public/:page", function (req, res, next) {
     var page = req.params.page
     console.log("Redirecting");
     console.log(req.originalUrl)

--- a/views/404.handlebars
+++ b/views/404.handlebars
@@ -3,7 +3,7 @@
     <title>Oops!</title>
     <!-- This 3rd-party stylesheet incorporates SVG icons from Font Awesome: http://fontawesome.com/ -->
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.8.1/css/all.css" crossorigin="anonymous">
-    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="/public/style.css">
 </head>
 
 <body>

--- a/views/home.handlebars
+++ b/views/home.handlebars
@@ -3,7 +3,7 @@
     <title>Quizicle</title>
     <!-- This 3rd-party stylesheet incorporates SVG icons from Font Awesome: http://fontawesome.com/ -->
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.8.1/css/all.css" crossorigin="anonymous">
-    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="/public/style.css">
 </head>
 
 <body>

--- a/views/quiz.handlebars
+++ b/views/quiz.handlebars
@@ -3,7 +3,7 @@
     <title>{{name}}</title>
     <!-- This 3rd-party stylesheet incorporates SVG icons from Font Awesome: http://fontawesome.com/ -->
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.8.1/css/all.css" crossorigin="anonymous">
-    <link rel="stylesheet" href="/style.css">
+    <link rel="stylesheet" href="/public/style.css">
 </head>
 
 <body>


### PR DESCRIPTION
I hate this jankiness and decided it was unbearable when I went to add assets.

- Redirects any request for `...public/...` to `./public/...`.
- When loading the error page and trying to get assets for a url like GET `quizicle.com/quiz/garbageurl` instead of trying to GET `quizicle.com/quiz/garbageurl/public/asset.name` it gets automatically redirected to GET `quizicle.com/public/asset.name` which guarantees the static file is served.
- Removes janky-ass fix I shoved in earlier.
- Also fixes the count on the cards and assigns an id of 1.